### PR TITLE
✨ Decorated Hex Color Codes

### DIFF
--- a/src/components/StyledContent.svelte
+++ b/src/components/StyledContent.svelte
@@ -130,5 +130,15 @@
         page-break-inside: avoid;
         break-inside: avoid;
     }
+    .hex-color-code {
+        @apply font-mono;
+        text-transform: lowercase;
+        font-size: smaller;
+    }
+    .hex-color-indicator {
+        margin-inline-end: var(--s-3);
+        top: -.1rem;
+        position: relative;
+    }
 
 </style>

--- a/src/renderers/markdown.js
+++ b/src/renderers/markdown.js
@@ -53,12 +53,65 @@ let mdContainers = {
     }
 };
 
+const hexColorDecorator = (state) => {
+    const hexColorRE = /([a-f0-9]{6}|[a-f0-9]{3})/i;
+    let content,
+        token,
+        max = state.posMax,
+        start = state.pos;
+
+    if (state.src.charCodeAt(start) !== 0x23/* # */) { return false; }
+    let found = hexColorRE.exec(state.src.slice(start));
+
+    if (!found) { return false; }
+
+    state.posMax = state.pos;
+    state.pos = start;
+    content = found[0];
+
+    // outer wrapper
+    token = state.push('css_open', 'span', 1);
+    token.attrs = [
+        ['class', 'hex-color-code']
+    ];
+
+    // inner wrapper
+    token = state.push('css_open', 'span', 1);
+    token.attrs = [
+        ['class', 'hex-color-indicator'],
+        ['style', `color:#${content}`]
+    ];
+
+    // black large circle
+    token = state.push('text', '', 0);
+    token.content = "\u2B24";
+
+    // close inner wrapper
+    token = state.push('css_close', 'span', -1);
+
+    // content itself is unchanged
+    token = state.push('text', '', 0);
+    token.content = `#${content}`;
+
+    // close outer wrapper
+    token = state.push('css_close', 'span', -1);
+
+    state.pos = state.posMax + content.length + 1;
+    state.posMax = max;
+
+    return true;
+};
+
+
 let md = require('markdown-it')(mdConfig)
     .use(require('markdown-it-footnote'))
     .use(require('markdown-it-sub'))
     .use(require('markdown-it-sup'))
     .use(require('markdown-it-container'), 'details', mdContainers.details)
-    .use(require('markdown-it-container'), 'info', mdContainers.info);
+    .use(require('markdown-it-container'), 'info', mdContainers.info)
+    .use((md) => {
+        md.inline.ruler.push("decoratedHexColorCodes", hexColorDecorator)
+    });
 
 md.renderer.rules.footnote_anchor = (tokens, idx, options, env, slf) => {
     let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);

--- a/src/renderers/markdown.js
+++ b/src/renderers/markdown.js
@@ -76,18 +76,28 @@ const hexColorDecorator = (state) => {
     ];
 
     // inner wrapper
-    token = state.push('css_open', 'span', 1);
+    token = state.push('svg_open', 'svg', 1);
     token.attrs = [
         ['class', 'hex-color-indicator'],
-        ['style', `color:#${content}`]
+        ['aria-hidden', true],
+        ['style', 'display: inline-block; height: 1rem;'],
+        ['viewBox', '0 0 100 100'],
     ];
 
-    // black large circle
-    token = state.push('text', '', 0);
-    token.content = "\u2B24";
+    token = state.push('circle_open', 'circle', 1);
+    token.attrs = [
+        ['cx', '50'],
+        ['cy', '50'],
+        ['r', '40'],
+        ['stroke', 'currentColor'],
+        ['stroke-width', '5'],
+        ['stroke-opacity', '20%'],
+        ['fill', `#${content}`]
+    ];
+    token = state.push('circle_close', 'circle', -1);
 
     // close inner wrapper
-    token = state.push('css_close', 'span', -1);
+    token = state.push('svg_close', 'svg', -1);
 
     // content itself is unchanged
     token = state.push('text', '', 0);


### PR DESCRIPTION
This adds an inline markdown-it plugin to find hex colors in content,
wrap them in a css class, and prepend them with a colored dot.

I'm not sure I understand the markdown-it API well enough to know if I'm
doing this "right", but it works and it doesn't seem to break anything!